### PR TITLE
Feature/#161824264 crud propagandas

### DIFF
--- a/app/DataTables/InstituicaoDataTable.php
+++ b/app/DataTables/InstituicaoDataTable.php
@@ -47,12 +47,13 @@ class InstituicaoDataTable extends DataTable
                 'dom'     => 'Bfrtip',
                 'order'   => [[0, 'desc']],
                 'buttons' => [
-                    'create',
-                    'export',
-                    'print',
-                    'reset',
-                    'reload',
+                    [
+                        'extend'  => 'create',
+                        'text'    => '<i class="fa fa-plus"></i> Criar nova',
+                    ],
                 ],
+                'language' => ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/Portuguese-Brasil.json'],
+
             ]);
     }
 

--- a/app/DataTables/PropagandaDataTable.php
+++ b/app/DataTables/PropagandaDataTable.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\DataTables;
+
+use App\Models\Propaganda;
+use Yajra\DataTables\Services\DataTable;
+use Yajra\DataTables\EloquentDataTable;
+
+class PropagandaDataTable extends DataTable
+{
+    /**
+     * Build DataTable class.
+     *
+     * @param mixed $query Results from query() method.
+     * @return \Yajra\DataTables\DataTableAbstract
+     */
+    public function dataTable($query)
+    {
+        $dataTable = new EloquentDataTable($query);
+
+        return $dataTable->addColumn('action', 'propagandas.datatables_actions');
+    }
+
+    /**
+     * Get query source of dataTable.
+     *
+     * @param \App\Models\Post $model
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function query(Propaganda $model)
+    {
+        return $model->newQuery();
+    }
+
+    /**
+     * Optional method if you want to use html builder.
+     *
+     * @return \Yajra\DataTables\Html\Builder
+     */
+    public function html()
+    {
+        return $this->builder()
+            ->columns($this->getColumns())
+            ->minifiedAjax()
+            ->addAction(['width' => '80px'])
+            ->parameters([
+                'dom'     => 'Bfrtip',
+                'order'   => [[0, 'desc']],
+                'buttons' => [
+                    [
+                        'extend'  => 'create',
+                        'text'    => '<i class="fa fa-plus"></i> Criar nova',
+                    ],
+                ],
+                'language' => ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/Portuguese-Brasil.json'],
+
+            ]);
+    }
+
+    /**
+     * Get columns.
+     *
+     * @return array
+     */
+    protected function getColumns()
+    {
+        return [
+            'nome'
+        ];
+    }
+
+    /**
+     * Get filename for export.
+     *
+     * @return string
+     */
+    protected function filename()
+    {
+        return 'propagandasdatatable_' . time();
+    }
+}

--- a/app/Http/Controllers/API/HomeAPIController.php
+++ b/app/Http/Controllers/API/HomeAPIController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use Auth;
+use Response;
+use Validator;
+use App\Models\User;
+use Illuminate\Http\Request;
+use App\Repositories\VideoRepository;
+use App\Repositories\PropagandaRepository;
+use App\Http\Controllers\AppBaseController;
+
+/**
+ * @resource HOME API, servindo as informaçoes que aparecem na HOME do aplicativo
+ *
+ * Auth API
+ */
+class HomeAPIController extends AppBaseController
+{
+
+    /** @var VideoRepository */
+    private $videoRepository;
+
+    /** @var PropagandaRepository */
+    private $propagandaRepository;
+
+    /**
+     * __construct - Com Repositorios necessarios
+     *
+     * @param VideoRepository $videoRepo
+     * @param PropagandaRepository $propagandaRepo
+     */
+    public function __construct(VideoRepository $videoRepo, PropagandaRepository $propagandaRepo) 
+    {
+        $this->videoRepository = $videoRepo;
+        $this->propagandaRepository = $propagandaRepo;
+    }
+
+    /**
+     * Metodo para retornar por GET as informacoes da Home do aplicativo
+     *
+     */
+    public function getHome()
+    {
+        $video = $this->videoRepository->getVideoEmDestaque();
+        $propagandas = $this->propagandaRepository->all()->toArray();
+
+        $retorno = [
+            'video' => $video->toArray(),
+            'propagandas' =>  $propagandas
+        ];
+
+        return $this->sendResponse($retorno, 'Video em destaque e Propagandas');
+    }
+    
+
+    
+
+}

--- a/app/Http/Controllers/PropagandaController.php
+++ b/app/Http/Controllers/PropagandaController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Flash;
+use Response;
+use App\Http\Requests;
+use App\Repositories\FotoRepository;
+use App\DataTables\PropagandaDataTable;
+use App\Repositories\PropagandaRepository;
+use App\Http\Controllers\AppBaseController;
+use App\Http\Requests\CreatePropagandaRequest;
+use App\Http\Requests\UpdatePropagandaRequest;
+
+class PropagandaController extends AppBaseController
+{
+    /** @var  PropagandaRepository */
+    private $propagandaRepository;
+
+    /** @var  FotoRepository */
+    private $fotoRepository;
+
+    /**
+     * __construct Recebendo os repositorios necessarios para a logica de propagandas
+     *
+     * @param PropagandaRepository $propagandaRepo
+     * @param FotoRepository $fotoRepo
+     */
+    public function __construct(PropagandaRepository $propagandaRepo, FotoRepository $fotoRepo)
+    {
+        $this->propagandaRepository = $propagandaRepo;
+        $this->fotoRepository = $fotoRepo;
+    }
+
+    /**
+     * Display a listing of the Propaganda.
+     *
+     * @param PropagandaDataTable $propagandaDataTable
+     * @return Response
+     */
+    public function index(PropagandaDataTable $propagandaDataTable)
+    {
+        return $propagandaDataTable->render('propagandas.index');
+    }
+
+    /**
+     * Show the form for creating a new Propaganda.
+     *
+     * @return Response
+     */
+    public function create()
+    {
+        return view('propagandas.create');
+    }
+
+    /**
+     * Store a newly created Propaganda in storage.
+     *
+     * @param CreatePropagandaRequest $request
+     *
+     * @return Response
+     */
+    public function store(CreatePropagandaRequest $request)
+    {
+        $input = $request->all();
+
+        $propaganda = $this->propagandaRepository->create($input);
+
+        /* Se houver um file na request, entao, salvar a foto  **/
+        if ($request->file) {
+            $foto = $this->fotoRepository->uploadAndCreate($request);
+            $propaganda->foto()->save($foto);
+
+            //Upload p/ Cloudinary e delete local
+            $publicId = 'propaganda_'.time();
+            $retorno = $this->fotoRepository->sendToCloudinary($foto, $publicId);
+            $this->fotoRepository->deleteLocal($foto->id);
+        }
+
+        Flash::success('Propaganda criada com sucesso.');
+        return redirect(route('propagandas.index'));
+    }
+
+    /**
+     * Display the specified Propaganda.
+     *
+     * @param  int $id
+     *
+     * @return Response
+     */
+    public function show($id)
+    {
+        $propaganda = $this->propagandaRepository->findWithoutFail($id);
+
+        if (empty($propaganda)) {
+            Flash::error('Propaganda não encontrada');
+
+            return redirect(route('propagandas.index'));
+        }
+
+        return view('propagandas.show')->with('propaganda', $propaganda);
+    }
+
+    /**
+     * Show the form for editing the specified Propaganda.
+     *
+     * @param  int $id
+     *
+     * @return Response
+     */
+    public function edit($id)
+    {
+        $propaganda = $this->propagandaRepository->findWithoutFail($id);
+
+        if (empty($propaganda)) {
+            Flash::error('Propaganda não encontrada');
+
+            return redirect(route('propagandas.index'));
+        }
+
+        return view('propagandas.edit')->with('propaganda', $propaganda);
+    }
+
+    /**
+     * Update the specified Propaganda in storage.
+     *
+     * @param  int              $id
+     * @param UpdatePropagandaRequest $request
+     *
+     * @return Response
+     */
+    public function update($id, UpdatePropagandaRequest $request)
+    {
+        $propaganda = $this->propagandaRepository->findWithoutFail($id);
+
+        if (empty($propaganda)) {
+            Flash::error('Propaganda não encontrada');
+            return redirect(route('propagandas.index'));
+        }
+
+        /* Se houver um file na request, entao, salvar a foto  **/
+        if ($request->file) {
+            $foto = $this->fotoRepository->uploadAndCreate($request);
+            $propaganda->foto()->delete();
+            $propaganda->foto()->save($foto);
+
+            //Upload p/ Cloudinary e delete local
+            $publicId = 'propaganda_'.time();
+            $retorno = $this->fotoRepository->sendToCloudinary($foto, $publicId);
+            $this->fotoRepository->deleteLocal($foto->id);
+        }
+        
+        $propaganda = $this->propagandaRepository->update($request->all(), $id);
+        Flash::success('Propaganda atualizada com sucesso.');
+        return redirect(route('propagandas.index'));
+    }
+
+    /**
+     * Remove the specified Propaganda from storage.
+     *
+     * @param  int $id
+     *
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        $propaganda = $this->propagandaRepository->findWithoutFail($id);
+        if (empty($propaganda)) {
+            Flash::error('Propaganda não encontrada');
+            return redirect(route('propagandas.index'));
+        }
+
+        $this->propagandaRepository->delete($id);
+        Flash::success('Propaganda removida com sucesso.');
+
+        return redirect(route('propagandas.index'));
+    }
+}

--- a/app/Http/Requests/CreatePropagandaRequest.php
+++ b/app/Http/Requests/CreatePropagandaRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Propaganda;
+
+class CreatePropagandaRequest extends FormRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return Propaganda::$rules;
+    }
+
+}

--- a/app/Http/Requests/UpdatePropagandaRequest.php
+++ b/app/Http/Requests/UpdatePropagandaRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Propaganda;
+
+class UpdatePropagandaRequest extends FormRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return Propaganda::$rules;
+    }
+}

--- a/app/Models/Propaganda.php
+++ b/app/Models/Propaganda.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Models;
+
+use Eloquent as Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Class Propaganda
+ * @package App\Models
+ * @version November 23, 2018, 6:36 pm BRST
+ *
+ * @property string nome
+ */
+class Propaganda extends Model
+{
+    use SoftDeletes;
+
+    public $table = 'propagandas';
+    
+    protected $dates = ['deleted_at'];
+
+    public $fillable = [
+        'nome'
+    ];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'nome' => 'string'
+    ];
+
+    /**
+     * Validation rules
+     *
+     * @var array
+     */
+    public static $rules = [
+        'nome' => 'required',
+        'file' => 'required|file',
+    ];
+
+
+    /** Array que contem os nomes das nested relations, que devem ser deletadas caso essa entidade seja deletada **/
+    public $relacoesDependentes = [
+        'foto',
+    ];
+
+    /** Array escondendo campos desnecessarios resposta do Eloquent. **/
+    public $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+        'foto',
+    ];
+
+    public $appends = [
+        'url' => 'url'
+    ];
+
+
+    /**
+     * Bindando Model Events para controlar o delete.
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        //Bindando o deleting para remover as relationships dependentes
+        static::deleting(function ($model) {
+            DeleteModelHelper::deleteRelationships($model);
+        });
+    }
+
+    
+    /**
+     * Cada Propaganda possuí uma Foto
+     *
+     * @return void
+     */
+    public function foto()
+    {
+        return $this->morphOne(\App\Models\Foto::class, 'owner');
+    }
+
+    /**
+     * Acessor para a URL da foto
+     */
+    public function getURLAttribute()
+    {
+        return $this->foto ? $this->foto->urlCloudinary : '';
+    }
+
+
+
+    
+}

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -52,6 +52,14 @@ class Video extends Model
         'youtube_id' => 'required',
     ];
 
+
+    /** Array escondendo campos desnecessarios resposta do Eloquent. **/
+    public $hidden = [
+        'created_at',
+        'updated_at',
+    ];
+
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      **/

--- a/app/Repositories/PropagandaRepository.php
+++ b/app/Repositories/PropagandaRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Propaganda;
+use InfyOm\Generator\Common\BaseRepository;
+
+/**
+ * Class PropagandaRepository
+ * @package App\Repositories
+ * @version November 23, 2018, 6:36 pm BRST
+ *
+ * @method Propaganda findWithoutFail($id, $columns = ['*'])
+ * @method Propaganda find($id, $columns = ['*'])
+ * @method Propaganda first($columns = ['*'])
+*/
+class PropagandaRepository extends BaseRepository
+{
+    /**
+     * @var array
+     */
+    protected $fieldSearchable = [
+        'nome'
+    ];
+
+    /**
+     * Configure the Model
+     **/
+    public function model()
+    {
+        return Propaganda::class;
+    }
+}

--- a/database/migrations/2018_11_23_183609_create_propagandas_table.php
+++ b/database/migrations/2018_11_23_183609_create_propagandas_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreatePropagandasTable extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('propagandas', function (Blueprint $table) {
+            $table->integer('id', true);
+            $table->string('nome');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('propagandas');
+    }
+}

--- a/resources/lang/pt-BR/validation.php
+++ b/resources/lang/pt-BR/validation.php
@@ -146,5 +146,6 @@ return [
         'title' => 'título',
         'username' => 'usuário',
         'year' => 'ano',
+        'file' => 'para upload de arquivo',
     ],
 ];

--- a/resources/model_schemas/Propaganda.json
+++ b/resources/model_schemas/Propaganda.json
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "id",
+        "dbType": "integer,true",
+        "htmlType": null,
+        "validations": null,
+        "searchable": false,
+        "fillable": false,
+        "primary": true,
+        "inForm": false,
+        "inIndex": false
+    },
+    {
+        "name": "nome",
+        "dbType": "string",
+        "htmlType": "text",
+        "validations": null,
+        "searchable": true,
+        "fillable": true,
+        "primary": false,
+        "inForm": true,
+        "inIndex": true
+    },
+    {
+        "name": "created_at",
+        "dbType": "datetime",
+        "htmlType": "date",
+        "validations": null,
+        "searchable": false,
+        "fillable": false,
+        "primary": false,
+        "inForm": false,
+        "inIndex": false
+    },
+    {
+        "name": "updated_at",
+        "dbType": "datetime",
+        "htmlType": "date",
+        "validations": null,
+        "searchable": false,
+        "fillable": false,
+        "primary": false,
+        "inForm": false,
+        "inIndex": false
+    }
+]

--- a/resources/views/instituicaos/create.blade.php
+++ b/resources/views/instituicaos/create.blade.php
@@ -2,9 +2,7 @@
 
 @section('content')
     <section class="content-header">
-        <h1>
-            Instituicao
-        </h1>
+        <h1>Instituições</h1>
     </section>
     <div class="content">
         @include('adminlte-templates::common.errors')

--- a/resources/views/instituicaos/edit.blade.php
+++ b/resources/views/instituicaos/edit.blade.php
@@ -2,9 +2,7 @@
 
 @section('content')
     <section class="content-header">
-        <h1>
-            Instituicao
-        </h1>
+        <h1>Instituições</h1>
    </section>
    <div class="content">
        @include('adminlte-templates::common.errors')

--- a/resources/views/instituicaos/fields.blade.php
+++ b/resources/views/instituicaos/fields.blade.php
@@ -12,6 +12,6 @@
 
 <!-- Submit Field -->
 <div class="form-group col-sm-12">
-    {!! Form::submit('Save', ['class' => 'btn btn-primary']) !!}
-    <a href="{!! route('instituicaos.index') !!}" class="btn btn-default">Cancel</a>
+    {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}
+    <a href="{!! route('instituicaos.index') !!}" class="btn btn-default">Cancelar</a>
 </div>

--- a/resources/views/instituicaos/index.blade.php
+++ b/resources/views/instituicaos/index.blade.php
@@ -2,10 +2,7 @@
 
 @section('content')
     <section class="content-header">
-        <h1 class="pull-left">Instituicaos</h1>
-        <h1 class="pull-right">
-           <a class="btn btn-primary pull-right" style="margin-top: -10px;margin-bottom: 5px" href="{!! route('instituicaos.create') !!}">Add New</a>
-        </h1>
+        <h1>Instituições</h1>
     </section>
     <div class="content">
         <div class="clearfix"></div>

--- a/resources/views/instituicaos/show.blade.php
+++ b/resources/views/instituicaos/show.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     <section class="content-header">
         <h1>
-            Instituicao
+            Instituição
         </h1>
     </section>
     <div class="content">
@@ -11,7 +11,7 @@
             <div class="box-body">
                 <div class="row" style="padding-left: 20px">
                     @include('instituicaos.show_fields')
-                    <a href="{!! route('instituicaos.index') !!}" class="btn btn-default">Back</a>
+                    <a href="{!! route('instituicaos.index') !!}" class="btn btn-default">Voltar</a>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -66,6 +66,13 @@
     <a href="{!! route('videos.index') !!}"><i class="fa fa-play"></i><span>Videos</span></a>
 </li>
 
+<li class="{{ Request::is('propagandas*') ? 'active' : '' }}">
+    <a href="{!! route('propagandas.index') !!}"><i class="fa fa-image"></i><span>Propagandas</span></a>
+</li>
+
+<li class="{{ Request::is('instituicaos*') ? 'active' : '' }}">
+    <a href="{!! route('instituicaos.index') !!}"><i class="fa fa-building"></i><span>Instituições</span></a>
+</li>
 @endrole
 
 
@@ -85,10 +92,10 @@
 <li class="{{ Request::is('faleConoscos*') ? 'active' : '' }}">
     <a href="{!! route('faleConoscos.index') !!}"><i class="fa fa-envelope"></i><span>Fale Conosco</span></a>
 </li>
-@endrole
-
 
 <li class="{{ Request::is('instituicaos*') ? 'active' : '' }}">
-    <a href="{!! route('instituicaos.index') !!}"><i class="fa fa-edit"></i><span>Instituicaos</span></a>
+    <a href="{!! route('instituicaos.index') !!}"><i class="fa fa-building"></i><span>Instituições</span></a>
 </li>
+
+@endrole
 

--- a/resources/views/propagandas/create.blade.php
+++ b/resources/views/propagandas/create.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="content-header">
+        <h1>
+            Propaganda
+        </h1>
+    </section>
+    <div class="content">
+        @include('adminlte-templates::common.errors')
+        <div class="box box-primary">
+
+            <div class="box-body">
+                <div class="row">
+                    {!! Form::open(['route' => 'propagandas.store', 'files' => true]) !!}
+
+                        @include('propagandas.fields')
+
+                    {!! Form::close() !!}
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/propagandas/datatables_actions.blade.php
+++ b/resources/views/propagandas/datatables_actions.blade.php
@@ -1,0 +1,15 @@
+{!! Form::open(['route' => ['propagandas.destroy', $id], 'method' => 'delete']) !!}
+<div class='btn-group'>
+    <a href="{{ route('propagandas.show', $id) }}" class='btn btn-default btn-xs'>
+        <i class="glyphicon glyphicon-eye-open"></i>
+    </a>
+    <a href="{{ route('propagandas.edit', $id) }}" class='btn btn-default btn-xs'>
+        <i class="glyphicon glyphicon-edit"></i>
+    </a>
+    {!! Form::button('<i class="glyphicon glyphicon-trash"></i>', [
+        'type' => 'submit',
+        'class' => 'btn btn-danger btn-xs',
+        'onclick' => "return confirm('Are you sure?')"
+    ]) !!}
+</div>
+{!! Form::close() !!}

--- a/resources/views/propagandas/edit.blade.php
+++ b/resources/views/propagandas/edit.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="content-header">
+        <h1>
+            Propaganda
+        </h1>
+   </section>
+   <div class="content">
+       @include('adminlte-templates::common.errors')
+       <div class="box box-primary">
+           <div class="box-body">
+               <div class="row">
+                   {!! Form::model($propaganda, ['route' => ['propagandas.update', $propaganda->id], 'method' => 'patch', 'files' => true]) !!}
+
+                        @include('propagandas.fields')
+
+                   {!! Form::close() !!}
+               </div>
+           </div>
+       </div>
+   </div>
+@endsection

--- a/resources/views/propagandas/fields.blade.php
+++ b/resources/views/propagandas/fields.blade.php
@@ -1,0 +1,17 @@
+<!-- Nome Field -->
+<div class="form-group col-sm-6">
+    {!! Form::label('nome', 'Nome:') !!}
+    {!! Form::text('nome', null, ['class' => 'form-control']) !!}
+</div>
+
+<div class="form-group col-sm-6">
+    @include('fotos.partials.fields', [
+        'label' => 'Foto:'
+    ])
+</div>
+
+<!-- Submit Field -->
+<div class="form-group col-sm-12">
+    {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}
+    <a href="{!! route('propagandas.index') !!}" class="btn btn-default">Cancelar</a>
+</div>

--- a/resources/views/propagandas/index.blade.php
+++ b/resources/views/propagandas/index.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="content-header">
+        <h1>Propagandas</h1>
+    </section>
+    <div class="content">
+        <div class="clearfix"></div>
+
+        @include('flash::message')
+
+        <div class="clearfix"></div>
+        <div class="box box-primary">
+            <div class="box-body">
+                    @include('propagandas.table')
+            </div>
+        </div>
+        <div class="text-center">
+        
+        </div>
+    </div>
+@endsection
+

--- a/resources/views/propagandas/show.blade.php
+++ b/resources/views/propagandas/show.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="content-header">
+        <h1>
+            Propaganda
+        </h1>
+    </section>
+    <div class="content">
+        <div class="box box-primary">
+            <div class="box-body">
+                <div class="row" style="padding-left: 20px">
+                    @include('propagandas.show_fields')
+                    <a href="{!! route('propagandas.index') !!}" class="btn btn-default">Voltar</a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/propagandas/show_fields.blade.php
+++ b/resources/views/propagandas/show_fields.blade.php
@@ -1,0 +1,31 @@
+<!-- Id Field -->
+<div class="col-xs-6">
+    {!! Form::label('id', 'Id:') !!}
+    <p>{!! $propaganda->id !!}</p>
+</div>
+
+<!-- Nome Field -->
+<div class="col-xs-6">
+    {!! Form::label('nome', 'Nome:') !!}
+    <p>{!! $propaganda->nome !!}</p>
+</div>
+
+<!-- Created At Field -->
+<div class="col-xs-6">
+    {!! Form::label('created_at', 'Created At:') !!}
+    <p>{!! $propaganda->created_at !!}</p>
+</div>
+
+<!-- Updated At Field -->
+<div class="col-xs-6">
+    {!! Form::label('updated_at', 'Updated At:') !!}
+    <p>{!! $propaganda->updated_at !!}</p>
+</div>
+
+<div class="col-xs-12">
+    <img src="{{$propaganda->url}}" alt="Foto da propaganda" class="img-responsive">
+</div>
+
+<div class="col-xs-12">
+<hr>
+</div>

--- a/resources/views/propagandas/table.blade.php
+++ b/resources/views/propagandas/table.blade.php
@@ -1,0 +1,10 @@
+@section('css')
+    @include('layouts.datatables_css')
+@endsection
+
+{!! $dataTable->table(['width' => '100%']) !!}
+
+@section('scripts')
+    @include('layouts.datatables_js')
+    {!! $dataTable->scripts() !!}
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,5 +67,8 @@ Route::get('sindicatos/{id}/videos', 'SindicatoAPIController@getVideosPorSindica
 //Video em destaque
 Route::get('video-home', 'VideoAPIController@getVideoHome');
 
+//Informaçoes da HOME do Aplicativo (Videos em destaque e Propagandas)
+Route::get('home', 'HomeAPIController@getHome');
+
 Route::resource('beneficios', 'BeneficioAPIController');
 Route::resource('videos', 'VideoAPIController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,3 +82,5 @@ Route::get('faleconosco/{id}', 'FaleConoscoController@createApp');
 Route::get('carteirinha/{id}', 'UserController@getCarteirinha');
 
 Route::resource('instituicaos', 'InstituicaoController');
+
+Route::resource('propagandas', 'PropagandaController');


### PR DESCRIPTION
CRUD de propagandas.

- Menu: 
![image](https://user-images.githubusercontent.com/9811888/48961726-ff5bbf80-ef5d-11e8-8bd8-ba9b4ed423eb.png)

- Scaffold (migration / views / model / controller / repositorio / requests)
- Relação com Foto `$propaganda->foto()` e acessor para a URL direto `$propaganda->url`
- Novo Controller da API `HomeAPIController` com o metodo `getHome()` pra servir as informaçoes da Home do aplicativo (Video em destaque e propagandas)
- Ajustes de tradução... 

- Endpoint da API --> `/api/home`
- Exemplo retorno ![image](https://user-images.githubusercontent.com/9811888/48961820-e7387000-ef5e-11e8-9f4c-322454efa9e8.png)

